### PR TITLE
Add Colorized Text for Required and Conflicting Nodes in Skill Tooltip

### DIFF
--- a/BraveryRPG/Assets/Data/Skill Data - Timeless Attack.asset
+++ b/BraveryRPG/Assets/Data/Skill Data - Timeless Attack.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3749fe0fc0f944fe2ac8db88705d596a, type: 3}
+  m_Name: Skill Data - Timeless Attack
+  m_EditorClassIdentifier: 
+  cost: 2
+  displayName: Timeless Attack
+  description: The echo can perform 1 attack.
+  icon: {fileID: 1100082596, guid: 4b4f1f12420c94c93ab90316aa2a5419, type: 3}

--- a/BraveryRPG/Assets/Data/Skill Data - Timeless Attack.asset.meta
+++ b/BraveryRPG/Assets/Data/Skill Data - Timeless Attack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 912dfd108a2b445cdbf8e98654cd41d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BraveryRPG/Assets/Scenes/SampleScene.unity
+++ b/BraveryRPG/Assets/Scenes/SampleScene.unity
@@ -150,6 +150,87 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1373728707}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &206418520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 206418521}
+  - component: {fileID: 206418523}
+  - component: {fileID: 206418522}
+  m_Layer: 5
+  m_Name: UI_TreeNode - Timeless Attack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &206418521
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206418520}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 636426721}
+  - {fileID: 1492008114}
+  - {fileID: 1319320115}
+  m_Father: {fileID: 607846946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -234.94946, y: -89.05057}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &206418522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206418520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cd0449cbff9c499b958104d24893f6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  connectionDetails:
+  - childNode: {fileID: 0}
+    direction: 0
+    length: 50
+  myConnectionLines:
+  - {fileID: 636426722}
+--- !u!114 &206418523
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206418520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a068eb36bde304f198f1b36ef09d9bcc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  requiredNodes:
+  - {fileID: 1245020437}
+  conflictNodes:
+  - {fileID: 716054849}
+  isUnlocked: 0
+  isLocked: 0
+  skillData: {fileID: 11400000, guid: 912dfd108a2b445cdbf8e98654cd41d3, type: 2}
+  skillName: Timeless Attack
+  skillCost: 2
+  skillIcon: {fileID: 1319320116}
+  lockedColorHex: '#808080'
 --- !u!1 &213554362
 GameObject:
   m_ObjectHideFlags: 0
@@ -233,6 +314,58 @@ PolygonCollider2D:
       - {x: -19, y: -34.5}
       - {x: 79, y: -34.5}
   m_UseDelaunayMesh: 0
+--- !u!1 &213933600
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 213933601}
+  - component: {fileID: 213933602}
+  m_Layer: 5
+  m_Name: Connection (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &213933601
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 213933600}
+  m_LocalRotation: {x: 0, y: 0, z: -0.38268346, w: 0.9238795}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1362980351}
+  m_Father: {fileID: 1245020436}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &213933602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 213933600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5965c1c2003114351b0e386ea5059867, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  centerNodePoint: {fileID: 213933601}
+  connectionLine: {fileID: 1362980351}
+  childNodeConnectionPoint: {fileID: 1974114238}
 --- !u!1 &251975463
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,9 +461,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1245020436}
-  - {fileID: 716054847}
-  - {fileID: 774263346}
+  - {fileID: 607846946}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -14492,6 +14623,81 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 1290259016742072960, guid: d5beecdc25904471e85f11a403201d19, type: 3}
   m_PrefabInstance: {fileID: 418815298}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &491555414
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 491555415}
+  - component: {fileID: 491555417}
+  - component: {fileID: 491555416}
+  m_Layer: 5
+  m_Name: ChildNodeConnectionPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &491555415
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491555414}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1925898018}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &491555416
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491555414}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.1745283, b: 0.1745283, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &491555417
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491555414}
+  m_CullTransparentMesh: 1
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -14698,7 +14904,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 5}
+  m_SizeDelta: {x: 0, y: 5}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &527384655
 MonoBehaviour:
@@ -14738,6 +14944,59 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 527384653}
   m_CullTransparentMesh: 1
+--- !u!1 &607846945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 607846946}
+  - component: {fileID: 607846947}
+  m_Layer: 5
+  m_Name: UI_SkillTree
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &607846946
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 607846945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1245020436}
+  - {fileID: 716054847}
+  - {fileID: 206418521}
+  - {fileID: 774263346}
+  m_Father: {fileID: 251975467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1026, y: 0}
+  m_SizeDelta: {x: 968, y: 520}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &607846947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 607846945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbad1ed9b93c4097be2faed47d34e4f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  skillPoints: 2
 --- !u!1 &619394800
 GameObject:
   m_ObjectHideFlags: 0
@@ -14822,6 +15081,58 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &636426720
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 636426721}
+  - component: {fileID: 636426722}
+  m_Layer: 5
+  m_Name: Connection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &636426721
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 636426720}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1925898018}
+  m_Father: {fileID: 206418521}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &636426722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 636426720}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5965c1c2003114351b0e386ea5059867, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  centerNodePoint: {fileID: 636426721}
+  connectionLine: {fileID: 1925898018}
+  childNodeConnectionPoint: {fileID: 491555415}
 --- !u!1001 &697918771
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14957,7 +15268,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 716054846}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -14965,11 +15276,11 @@ RectTransform:
   - {fileID: 2004463344}
   - {fileID: 1083417398}
   - {fileID: 1273258829}
-  m_Father: {fileID: 251975467}
+  m_Father: {fileID: 607846946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 592, y: -88.50003}
+  m_AnchoredPosition: {x: -434, y: -87.50003}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &716054848
@@ -14986,9 +15297,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   connectionDetails:
   - childNode: {fileID: 0}
-    direction: 5
-    length: 250
-  connections:
+    direction: 0
+    length: 50
+  myConnectionLines:
   - {fileID: 2004463345}
 --- !u!114 &716054849
 MonoBehaviour:
@@ -15002,12 +15313,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a068eb36bde304f198f1b36ef09d9bcc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  skillData: {fileID: 11400000, guid: 29a6531e6109a4c8597894b7873274e4, type: 2}
-  skillName: Healing Wisp
-  skillIcon: {fileID: 1273258830}
-  lockedColorHex: '#808080'
+  requiredNodes:
+  - {fileID: 1245020437}
+  conflictNodes:
+  - {fileID: 206418523}
   isUnlocked: 0
   isLocked: 0
+  skillData: {fileID: 11400000, guid: 29a6531e6109a4c8597894b7873274e4, type: 2}
+  skillName: Healing Wisp
+  skillCost: 2
+  skillIcon: {fileID: 1273258830}
+  lockedColorHex: '#808080'
 --- !u!1 &718202642
 GameObject:
   m_ObjectHideFlags: 0
@@ -15142,7 +15458,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 774263345}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -15152,11 +15468,11 @@ RectTransform:
   - {fileID: 1453824485}
   - {fileID: 1393039442}
   - {fileID: 1066824156}
-  m_Father: {fileID: 251975467}
+  m_Father: {fileID: 607846946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1300, y: 0}
+  m_AnchoredPosition: {x: 274, y: 0}
   m_SizeDelta: {x: 420, y: 520}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &774263347
@@ -15175,6 +15491,11 @@ MonoBehaviour:
   skillName: {fileID: 1453824486}
   skillDescription: {fileID: 1393039443}
   skillRequirements: {fileID: 1066824157}
+  hexConditionMet: '#E3D100'
+  hexConditionNotMet: '#EC0000'
+  hexImportantInfo: '#8BADFF'
+  colorPickerHelper: {r: 0.5424528, g: 0.6747478, b: 1, a: 1}
+  lockedSkillText: You've taken a diffrent path - this skill is now locked.
 --- !u!1 &790654195
 GameObject:
   m_ObjectHideFlags: 0
@@ -15974,19 +16295,20 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1245020435}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 276441715}
+  - {fileID: 213933601}
   - {fileID: 1764161727}
   - {fileID: 1136982842}
-  m_Father: {fileID: 251975467}
+  m_Father: {fileID: 607846946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 592, y: 110}
+  m_AnchoredPosition: {x: -434, y: 110}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1245020437
@@ -16001,12 +16323,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a068eb36bde304f198f1b36ef09d9bcc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  skillData: {fileID: 11400000, guid: 6c3d88dc596f04de985b18a4a9a08925, type: 2}
-  skillName: Time Echo
-  skillIcon: {fileID: 1136982843}
-  lockedColorHex: '#808080'
+  requiredNodes: []
+  conflictNodes: []
   isUnlocked: 0
   isLocked: 0
+  skillData: {fileID: 11400000, guid: 6c3d88dc596f04de985b18a4a9a08925, type: 2}
+  skillName: Time Echo
+  skillCost: 1
+  skillIcon: {fileID: 1136982843}
+  lockedColorHex: '#808080'
 --- !u!114 &1245020438
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16023,8 +16348,12 @@ MonoBehaviour:
   - childNode: {fileID: 716054848}
     direction: 6
     length: 200
-  connections:
+  - childNode: {fileID: 206418522}
+    direction: 5
+    length: 284
+  myConnectionLines:
   - {fileID: 276441716}
+  - {fileID: 213933602}
 --- !u!1 &1273258828
 GameObject:
   m_ObjectHideFlags: 0
@@ -16220,6 +16549,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1373728707}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1319320114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1319320115}
+  - component: {fileID: 1319320117}
+  - component: {fileID: 1319320116}
+  m_Layer: 5
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1319320115
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1319320114}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 206418521}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 82, y: 82}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1319320116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1319320114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1100082596, guid: 4b4f1f12420c94c93ab90316aa2a5419, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1319320117
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1319320114}
+  m_CullTransparentMesh: 1
 --- !u!1 &1330031519
 GameObject:
   m_ObjectHideFlags: 0
@@ -16374,6 +16778,82 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1362980350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1362980351}
+  - component: {fileID: 1362980353}
+  - component: {fileID: 1362980352}
+  m_Layer: 5
+  m_Name: ConnectionLine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1362980351
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362980350}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1974114238}
+  m_Father: {fileID: 213933601}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 284, y: 5}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1362980352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362980350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1362980353
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362980350}
+  m_CullTransparentMesh: 1
 --- !u!1 &1373728703
 GameObject:
   m_ObjectHideFlags: 0
@@ -16974,6 +17454,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1453824484}
+  m_CullTransparentMesh: 1
+--- !u!1 &1492008113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1492008114}
+  - component: {fileID: 1492008116}
+  - component: {fileID: 1492008115}
+  m_Layer: 5
+  m_Name: Borders
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1492008114
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492008113}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 206418521}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1492008115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492008113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8721326, g: 0.9811321, b: 0.6803133, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -2129552351283700800, guid: aec390328ee6444c78faa14149105a4c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1492008116
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492008113}
   m_CullTransparentMesh: 1
 --- !u!1 &1551594033
 GameObject:
@@ -51184,6 +51739,82 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1 &1925898017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1925898018}
+  - component: {fileID: 1925898020}
+  - component: {fileID: 1925898019}
+  m_Layer: 5
+  m_Name: ConnectionLine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1925898018
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925898017}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 491555415}
+  m_Father: {fileID: 636426721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 5}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1925898019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925898017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1925898020
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925898017}
+  m_CullTransparentMesh: 1
 --- !u!1 &1926399616
 GameObject:
   m_ObjectHideFlags: 0
@@ -51271,6 +51902,81 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1974114237
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1974114238}
+  - component: {fileID: 1974114240}
+  - component: {fileID: 1974114239}
+  m_Layer: 5
+  m_Name: ChildNodeConnectionPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1974114238
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1974114237}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1362980351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &1974114239
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1974114237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.1745283, b: 0.1745283, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1974114240
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1974114237}
+  m_CullTransparentMesh: 1
 --- !u!1 &2004463343
 GameObject:
   m_ObjectHideFlags: 0
@@ -51295,7 +52001,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2004463343}
-  m_LocalRotation: {x: 0, y: 0, z: -0.38268346, w: 0.9238795}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/BraveryRPG/Assets/Scripts/UI/UI_SkillTooltip.cs
+++ b/BraveryRPG/Assets/Scripts/UI/UI_SkillTooltip.cs
@@ -1,33 +1,94 @@
+using System.Text;
 using TMPro;
 using UnityEngine;
 
 public class UI_SkillTooltip : UI_Tooltip
 {
+    private UI ui;
+    private UI_SkillTree skillTree;
+
     [SerializeField] private TextMeshProUGUI skillName;
     [SerializeField] private TextMeshProUGUI skillDescription;
     [SerializeField] private TextMeshProUGUI skillRequirements;
 
-    public override void ShowTooltip(bool show, RectTransform targetRect)
+    [Space]
+    [Tooltip("Hex value to colorize text for prerequisite conditions that HAVE been met.")]
+    [SerializeField] private string hexConditionMet;
+
+    [Tooltip("Hex value to colorize text for prerequisite conditions that have NOT been met.")]
+    [SerializeField] private string hexConditionNotMet;
+
+    [Tooltip("Hex value to colorize text for important info, such as other skills that will be locked out.")]
+    [SerializeField] private string hexImportantInfo;
+    [SerializeField] private Color colorPickerHelper = Color.yellow;
+    [SerializeField] private string lockedSkillText = "You've taken a diffrent path - this skill is now locked.";
+
+    protected override void Awake()
     {
-        base.ShowTooltip(show, targetRect);
+        base.Awake();
+        ui = GetComponentInParent<UI>();
+        skillTree = ui.GetComponentInChildren<UI_SkillTree>(true);
     }
 
     /// <summary>
-    /// Overload that accepts a Skill Data ScriptableObject instance to populate
-    /// the tooltip with skill details.
+    /// Overload that accepts a [UI_TreeNode] containing a Skill Data ScriptableObject
+    // instance to populate the tooltip with skill details.
     /// </summary>
     /// <param name="show"></param>
     /// <param name="targetRect"></param>
-    /// <param name="skillData"></param>
-    public void ShowTooltip(bool show, RectTransform targetRect, Skill_DataSO skillData)
+    /// <param name="node"></param>
+    public void ShowTooltip(bool show, RectTransform targetRect, UI_TreeNode node)
     {
         base.ShowTooltip(show, targetRect);
 
         if (!show) return;
 
-        skillName.text = skillData.displayName;
-        skillDescription.text = skillData.description;
-        skillRequirements.text = "Requirements: \n"
-            + " - " + skillData.cost + " skill point.";
+        skillName.text = node.skillData.displayName;
+        skillDescription.text = node.skillData.description;
+
+        string skillLockedText = GetColoredText(hexImportantInfo, lockedSkillText);
+        string requirements = node.isLocked
+            ? skillLockedText
+            : GetRequirements(node.skillData.cost, node.requiredNodes, node.conflictNodes);
+        skillRequirements.text = requirements;
+    }
+
+    private string GetRequirements(int skillCost, UI_TreeNode[] requiredNodes, UI_TreeNode[] conflictNodes)
+    {
+        StringBuilder sb = new();
+
+        sb.AppendLine("Requirements:");
+
+        string costColor = skillTree.EnoughSkillPoints(skillCost) ? hexConditionMet : hexConditionNotMet;
+        string costText = $"- {skillCost} skill point(s)";
+        string finalCostText = GetColoredText(costColor, costText);
+
+        sb.AppendLine(finalCostText);
+
+        foreach (var requiredNode in requiredNodes)
+        {
+            string nodeColor = requiredNode.isUnlocked ? hexConditionMet : hexConditionNotMet;
+            string nodeText = $"- {requiredNode.skillData.displayName}";
+            string finalNodeText = GetColoredText(nodeColor, nodeText);
+
+            sb.AppendLine(finalNodeText);
+        }
+
+        if (conflictNodes.Length <= 0)
+        {
+            return sb.ToString();
+        }
+
+        sb.AppendLine(); // Spacing
+        sb.AppendLine(GetColoredText(hexImportantInfo, "Locks out: "));
+
+        foreach (var conflictNode in conflictNodes)
+        {
+            string nodeText = $"- {conflictNode.skillData.displayName}";
+            string finalNodeText = GetColoredText(hexImportantInfo, nodeText);
+            sb.AppendLine(finalNodeText);
+        }
+
+        return sb.ToString();
     }
 }

--- a/BraveryRPG/Assets/Scripts/UI/UI_SkillTree.cs
+++ b/BraveryRPG/Assets/Scripts/UI/UI_SkillTree.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class UI_SkillTree : MonoBehaviour
+{
+    [SerializeField] private int skillPoints;
+    // [SerializeField] private UI_TreeConnectHandler[] parentNodes;
+
+    private void Start()
+    {
+        // UpdateAllConnections();
+    }
+
+    [ContextMenu("Reset Skill Tree")]
+    public void RefundAllSkills()
+    {
+        UI_TreeNode[] skillNodes = GetComponentsInChildren<UI_TreeNode>();
+
+        foreach (var node in skillNodes)
+        {
+            // node.Refund();
+        }
+    }
+
+    public bool EnoughSkillPoints(int cost) => skillPoints >= cost;
+
+    public void RemoveSkillPoints(int cost) => skillPoints -= cost;
+
+    public void AddSkillPoints(int points) => skillPoints += points;
+
+    // [ContextMenu("Update All Connections")]
+    // public void UpdateAllConnections()
+    // {
+    //     foreach (var node in parentNodes)
+    //     {
+    //         node.UpdateAllConnections();
+    //     }
+    // }
+}

--- a/BraveryRPG/Assets/Scripts/UI/UI_SkillTree.cs.meta
+++ b/BraveryRPG/Assets/Scripts/UI/UI_SkillTree.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ccbad1ed9b93c4097be2faed47d34e4f

--- a/BraveryRPG/Assets/Scripts/UI/UI_Tooltip.cs
+++ b/BraveryRPG/Assets/Scripts/UI/UI_Tooltip.cs
@@ -16,7 +16,7 @@ public class UI_Tooltip : MonoBehaviour
     /// </summary>
     [SerializeField] private Vector2 offset = new(280f, 20f);
 
-    void Awake()
+    protected virtual void Awake()
     {
         rect = GetComponent<RectTransform>();
     }
@@ -68,5 +68,11 @@ public class UI_Tooltip : MonoBehaviour
         }
 
         rect.position = targetPosition;
+    }
+
+    /// <returns>The text wrapped with HTML color tags with the input hex color.</returns>
+    protected string GetColoredText(string color, string text)
+    {
+        return $"<color={color}>{text}</color>";
     }
 }

--- a/BraveryRPG/Assets/Scripts/UI/UI_TreeConnectHandler.cs
+++ b/BraveryRPG/Assets/Scripts/UI/UI_TreeConnectHandler.cs
@@ -5,12 +5,12 @@ using UnityEngine.UI;
 [Serializable]
 public class UI_TreeConnectDetails
 {
-    [Tooltip("A UI_TreeNode instance, like a Skill Tree Node prefab.")]
+    [Tooltip("A child UI_TreeNode instance, like a Skill Tree Node prefab.")]
     public UI_TreeConnectHandler childNode;
 
     public NodeDirectionType direction;
 
-    [Range(100f, 350f)]
+    [Range(50f, 350f)]
     public float length;
 }
 
@@ -23,23 +23,18 @@ public class UI_TreeConnectHandler : MonoBehaviour
     [Tooltip("Array containing a child UI_TreeNode endpoint, Line Direction and Line Length.")]
     [SerializeField] private UI_TreeConnectDetails[] connectionDetails;
 
-    [Tooltip("Should be the 'Connection' group (parent object containing one or more child lines).")]
-    [SerializeField] private UI_TreeConnection[] connections;
+    [Tooltip("The 'Connection' groups (parent object containing one or more child lines) originating from this Skill Node. If this Skill does not have any children, this can be empty.")]
+    [SerializeField] private UI_TreeConnection[] myConnectionLines;
 
-    private RectTransform rect;
+    private RectTransform Rect => GetComponent<RectTransform>();
 
     private void OnValidate()
     {
         if (connectionDetails.Length <= 0) return;
 
-        if (rect == null)
+        if (connectionDetails.Length != myConnectionLines.Length)
         {
-            rect = GetComponent<RectTransform>();
-        }
-
-        if (connectionDetails.Length != connections.Length)
-        {
-            Debug.LogWarning("Details Array Size should match Connections Array Size - " + gameObject.name);
+            Debug.Log("Details Array Size should match Connections Array Size - " + gameObject.name);
             return;
         }
 
@@ -51,9 +46,9 @@ public class UI_TreeConnectHandler : MonoBehaviour
         for (int i = 0; i < connectionDetails.Length; i++)
         {
             var detail = connectionDetails[i];
-            var connection = connections[i];
+            var connection = myConnectionLines[i];
 
-            Vector2 targetPosition = connection.GetConnectionPoint(rect);
+            Vector2 targetPosition = connection.GetConnectionPoint(Rect);
             // Image connectionImage = connection.GetConnectionImage();
 
             connection.DirectConnection(detail.direction, detail.length, 0f); // FIXME
@@ -68,5 +63,5 @@ public class UI_TreeConnectHandler : MonoBehaviour
 
     // public void SetConnectionImage(Image image) => connectionImage = image;
 
-    public void SetPosition(Vector2 position) => rect.anchoredPosition = position;
+    public void SetPosition(Vector2 position) => Rect.anchoredPosition = position;
 }


### PR DESCRIPTION
## Feats:
- Requirements are colorized in Yellow and Red text.
- Important info is shown in light-Blue text to denote conflicting skills that will be locked-out.