### PR TITLE
Bugfixes to Dash and Ultimate Invulnerability and Polish the Skill Tree UI

### DIFF
--- a/BraveryRPG/Assets/Graphics/UI/Background.png.meta
+++ b/BraveryRPG/Assets/Graphics/UI/Background.png.meta
@@ -46,13 +46,13 @@ TextureImporter:
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 2
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 32
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 1, y: 1, z: 1, w: 1}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -108,7 +108,7 @@ TextureImporter:
         width: 53
         height: 53
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -125,8 +125,8 @@ TextureImporter:
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
-    internalID: 0
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 1537655665
     vertices: []
     indices: 
     edges: []

--- a/BraveryRPG/Assets/Scenes/SampleScene.unity
+++ b/BraveryRPG/Assets/Scenes/SampleScene.unity
@@ -2082,7 +2082,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -123.85852, y: -157.73053}
+  m_AnchoredPosition: {x: -118.85852, y: -157.73053}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &359476815
@@ -2241,7 +2241,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &365024317
@@ -31588,7 +31588,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -91.34888, y: 84.214905}
+  m_AnchoredPosition: {x: -161.78253, y: -113.28137}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &449954778
@@ -32029,7 +32029,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -57.15204, y: -342.13403}
+  m_AnchoredPosition: {x: -52.151978, y: -342.13403}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &491228002
@@ -32703,13 +32703,13 @@ RectTransform:
   - {fileID: 365024316}
   - {fileID: 2106783200}
   - {fileID: 1099504821}
-  - {fileID: 491228001}
   - {fileID: 949960063}
+  - {fileID: 491228001}
   m_Father: {fileID: 607846946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -950, y: 300}
+  m_AnchoredPosition: {x: 130, y: 190}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &584547789
@@ -32749,7 +32749,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 125.894775, y: -173.70325}
+  m_AnchoredPosition: {x: 130.89478, y: -173.70325}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &584547791
@@ -32931,7 +32931,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 70.43359, y: 197.49625}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &590103733
@@ -33017,6 +33017,8 @@ GameObject:
   m_Component:
   - component: {fileID: 607846946}
   - component: {fileID: 607846947}
+  - component: {fileID: 607846949}
+  - component: {fileID: 607846948}
   m_Layer: 5
   m_Name: UI_SkillTree
   m_TagString: Untagged
@@ -33045,8 +33047,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1026, y: 0}
-  m_SizeDelta: {x: 968, y: 520}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1720, y: 840}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &607846947
 MonoBehaviour:
@@ -33060,13 +33062,51 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ccbad1ed9b93c4097be2faed47d34e4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  skillPoints: 14
+  skillPoints: 20
   parentNodes:
   - {fileID: 1245020438}
   - {fileID: 590103731}
   - {fileID: 365024315}
   - {fileID: 1125188514}
   - {fileID: 1538388628}
+--- !u!114 &607846948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 607846945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.78431374}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ce26405e2439347c5ab52a15a6af53f9, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &607846949
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 607846945}
+  m_CullTransparentMesh: 1
 --- !u!1 &612719116
 GameObject:
   m_ObjectHideFlags: 0
@@ -33227,6 +33267,142 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &620752460
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 620752461}
+  - component: {fileID: 620752463}
+  - component: {fileID: 620752462}
+  m_Layer: 5
+  m_Name: SkillCooldown
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &620752461
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620752460}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 774263346}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -84}
+  m_SizeDelta: {x: -36, y: 52}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &620752462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620752460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Skill cooldown text.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: d4eefdaaba87c4bfa934e469471f3064, type: 2}
+  m_sharedMaterial: {fileID: 3241670640150995401, guid: d4eefdaaba87c4bfa934e469471f3064, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 22
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &620752463
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620752460}
+  m_CullTransparentMesh: 1
 --- !u!1 &636426720
 GameObject:
   m_ObjectHideFlags: 0
@@ -33671,7 +33847,7 @@ MonoBehaviour:
   - childNode: {fileID: 2113420231}
     direction: 7
     length: 207
-    rotation: 0
+    rotation: 8
   - childNode: {fileID: 55338450}
     direction: 6
     length: 305
@@ -33920,6 +34096,7 @@ RectTransform:
   - {fileID: 790654196}
   - {fileID: 1453824485}
   - {fileID: 1393039442}
+  - {fileID: 620752461}
   - {fileID: 1066824156}
   m_Father: {fileID: 251975467}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -33943,6 +34120,7 @@ MonoBehaviour:
   offset: {x: 280, y: 20}
   skillName: {fileID: 1453824486}
   skillDescription: {fileID: 1393039443}
+  skillCooldown: {fileID: 620752462}
   skillRequirements: {fileID: 1066824157}
   hexConditionMet: '#E3D100'
   hexConditionNotMet: '#EC0000'
@@ -34559,7 +34737,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   skillType: 1
-  upgradeType: 16
+  upgradeType: 0
   cooldown: 1
   timeEchoPrefab: {fileID: 4453593416109140261, guid: c3f2e39ae55824ee99491055bb999ba5, type: 3}
   timeEchoDuration: 8
@@ -34580,7 +34758,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   skillType: 4
-  upgradeType: 23
+  upgradeType: 0
   cooldown: 5
   domainPrefab: {fileID: 8578793570240846509, guid: 46770b3707dd34c6ca46e50c4e0e07b5, type: 3}
   slowDownPercent: 0.8
@@ -34929,17 +35107,17 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1245020436}
-  - {fileID: 716054847}
-  - {fileID: 206418521}
-  - {fileID: 2113420233}
-  - {fileID: 55338452}
   - {fileID: 490375149}
   - {fileID: 288941556}
+  - {fileID: 2113420233}
+  - {fileID: 55338452}
+  - {fileID: 716054847}
+  - {fileID: 206418521}
   m_Father: {fileID: 607846946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -510, y: 300}
+  m_AnchoredPosition: {x: 508, y: 190}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &923936972
@@ -35258,7 +35436,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 84.8064, y: -340.0904}
+  m_AnchoredPosition: {x: 89.8064, y: -340.0904}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &949960064
@@ -35475,7 +35653,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -135.89478, y: -173.70325}
+  m_AnchoredPosition: {x: -130.89478, y: -173.70325}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &958423788
@@ -36346,7 +36524,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 84.8064, y: -192.5904}
+  m_AnchoredPosition: {x: 89.8064, y: -192.5904}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1099504822
@@ -36660,7 +36838,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1125188516
@@ -37551,7 +37729,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: -247.5}
+  m_AnchoredPosition: {x: 0, y: -247.50003}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1232293979
@@ -38470,7 +38648,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 104.729126, y: -194.50333}
+  m_AnchoredPosition: {x: 34.295532, y: -391.9996}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1331991642
@@ -39033,7 +39211,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentHealth: 0
-  isDead: 0
   regenInterval: 1
   canRegenerateHealth: 1
   onDamageKnockback: {x: 2.5, y: 2}
@@ -40323,7 +40500,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1538388630
@@ -41274,7 +41451,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1310, y: 420}
+  m_AnchoredPosition: {x: -228, y: 209}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1704484981
@@ -41518,7 +41695,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -91.34888, y: -113.28516}
+  m_AnchoredPosition: {x: -161.7826, y: -310.7814}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1740708465
@@ -42833,7 +43010,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 104.729126, y: 2.996704}
+  m_AnchoredPosition: {x: 34.295532, y: -194.49957}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1902035486
@@ -84454,7 +84631,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2004463343}
-  m_LocalRotation: {x: 0, y: 0, z: -0.92387956, w: 0.38268346}
+  m_LocalRotation: {x: 0, y: 0, z: -0.8949344, w: 0.4461978}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -84586,15 +84763,15 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 590103732}
+  - {fileID: 1738595593}
   - {fileID: 449954777}
   - {fileID: 1902035485}
-  - {fileID: 1738595593}
   - {fileID: 1331991641}
   m_Father: {fileID: 607846946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1710, y: 102}
+  m_AnchoredPosition: {x: -585, y: 190}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2079487471
@@ -84709,7 +84886,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -57.15204, y: -194.63403}
+  m_AnchoredPosition: {x: -52.151978, y: -194.63403}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2106783201
@@ -84832,7 +85009,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -144.6034, y: -342.10333}
+  m_AnchoredPosition: {x: -123.07129, y: -360.82098}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2136683471
@@ -84870,7 +85047,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1740, y: -270}
+  m_AnchoredPosition: {x: -228, y: -178}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2136684540
@@ -84910,7 +85087,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 113.85852, y: -157.73053}
+  m_AnchoredPosition: {x: 118.85846, y: -157.73053}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2136684542

--- a/BraveryRPG/Assets/Scripts/Enemies/Enemy.cs
+++ b/BraveryRPG/Assets/Scripts/Enemies/Enemy.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 public class Enemy : Entity
 {
+    public Enemy_Health health { get; private set; }
+
     public Enemy_IdleState IdleState { get; protected set; }
     public Enemy_MoveState MoveState { get; protected set; }
     public Enemy_AttackState AttackState { get; protected set; }
@@ -65,6 +67,8 @@ public class Enemy : Entity
     protected override void Awake()
     {
         base.Awake();
+
+        health = GetComponent<Enemy_Health>();
     }
 
     protected override void Start()

--- a/BraveryRPG/Assets/Scripts/Enemies/Enemy_Health.cs
+++ b/BraveryRPG/Assets/Scripts/Enemies/Enemy_Health.cs
@@ -9,6 +9,9 @@ public class Enemy_Health : Entity_Health
 
     public override bool TakeDamage(float damage, float elementalDamage, ElementType element, Transform damageDealer)
     {
+        // Check whether the enemy is currently invulnerable / invincible.
+        if (!canTakeDamage) return false;
+
         bool wasHit = base.TakeDamage(damage, elementalDamage, element, damageDealer);
 
         if (!wasHit)

--- a/BraveryRPG/Assets/Scripts/Entity/Entity_Health.cs
+++ b/BraveryRPG/Assets/Scripts/Entity/Entity_Health.cs
@@ -40,16 +40,6 @@ public class Entity_Health : MonoBehaviour, IDamageable
     [SerializeField] protected float currentHealth;
 
     /// <summary>
-    /// Flag indicating whether this entity has died.
-    /// 
-    /// Once set to true, this prevents the entity from taking additional damage
-    /// and can be used by other systems to check death state. The flag is
-    /// automatically set when health reaches zero and should not be manually
-    /// modified unless implementing resurrection mechanics.
-    /// </summary>
-    [SerializeField] protected bool isDead;
-
-    /// <summary>
     /// Health regeneration rate frequency, in seconds. Typically every 1 second.
     /// </summary>
     [Header("Health Regen")]
@@ -58,6 +48,17 @@ public class Entity_Health : MonoBehaviour, IDamageable
     [SerializeField] private bool canRegenerateHealth = true;
 
     public float lastDamageTaken { get; private set; }
+
+    /// <summary>
+    /// Flag indicating whether this entity has died.
+    /// 
+    /// Once set to true, this prevents the entity from taking additional damage
+    /// and can be used by other systems to check death state. The flag is
+    /// automatically set when health reaches zero and should not be manually
+    /// modified unless implementing resurrection mechanics.
+    /// </summary>
+    public bool isDead { get; private set; }
+    protected bool canTakeDamage = true;
 
     /// <summary>
     /// The knockback force applied when the entity receives normal damage.
@@ -201,6 +202,8 @@ public class Entity_Health : MonoBehaviour, IDamageable
     {
         if (isDead) return false;
 
+        if (!canTakeDamage) return false;
+
         if (AttackEvaded())
         {
             Debug.Log($"{gameObject.name} evaded the attack!");
@@ -239,6 +242,12 @@ public class Entity_Health : MonoBehaviour, IDamageable
 
         return true;
     }
+
+    /// <summary>
+    /// Sets the entity invulnerable status, which affects whether the TakeDamage()
+    /// function will apply damage and status effects to the entity.
+    /// </summary>
+    public void SetCanTakeDamage(bool canTakeDamage) => this.canTakeDamage = canTakeDamage;
 
     private bool AttackEvaded()
     {

--- a/BraveryRPG/Assets/Scripts/Player/PlayerStates/Player_DashState.cs
+++ b/BraveryRPG/Assets/Scripts/Player/PlayerStates/Player_DashState.cs
@@ -27,6 +27,9 @@ public class Player_DashState : PlayerState
         // Prevent player from gradually descending while dashing (this maintains
         // a constant horizontal linear movement from ledges).
         rb.gravityScale = 0;
+
+        // Make the player invulnerable while dashing.
+        player.Health.SetCanTakeDamage(false);
     }
 
     public override void Update()
@@ -60,6 +63,8 @@ public class Player_DashState : PlayerState
         // and we transition to the Falling state.
         player.SetVelocity(0, 0);
         rb.gravityScale = originalGravityScale;
+
+        player.Health.SetCanTakeDamage(true);
     }
 
     private void CancelDashIfNeeded()

--- a/BraveryRPG/Assets/Scripts/Player/PlayerStates/Player_DomainExpansionState.cs
+++ b/BraveryRPG/Assets/Scripts/Player/PlayerStates/Player_DomainExpansionState.cs
@@ -26,7 +26,9 @@ public class Player_DomainExpansionState : PlayerState
 
         // Apply upward velocity movement.
         player.SetVelocity(0, player.riseSpeed);
-        // player.Health.SetCanTakeDamage(false);
+
+        // Make the player invulnerable while the Ultimate Spell sequence is playing out.
+        player.Health.SetCanTakeDamage(false);
     }
 
     public override void Update()
@@ -58,7 +60,7 @@ public class Player_DomainExpansionState : PlayerState
     {
         base.Exit();
         createdDomain = false;
-        // player.Health.SetCanTakeDamage(true);
+        player.Health.SetCanTakeDamage(true);
     }
 
     private void Levitate()

--- a/BraveryRPG/Assets/Scripts/SkillSystem/Skill_Base.cs
+++ b/BraveryRPG/Assets/Scripts/SkillSystem/Skill_Base.cs
@@ -39,6 +39,9 @@ public class Skill_Base : MonoBehaviour
         upgradeType = upgrade.upgradeType;
         cooldown = upgrade.cooldown;
         damageScaleData = upgrade.damageScaleData;
+
+        // Allow skills to be immediately used when they are first unlocked.
+        ResetCooldown();
     }
 
     public virtual bool CanUseSkill()
@@ -74,5 +77,5 @@ public class Skill_Base : MonoBehaviour
     /// <param name="cooldownReduction"></param>
     public void ReduceCooldownBy(float cooldownReduction) => lastTimeUsed += cooldownReduction;
 
-    public void ResetCooldown() => lastTimeUsed = Time.time;
+    public void ResetCooldown() => lastTimeUsed = Time.time - cooldown;
 }

--- a/BraveryRPG/Assets/Scripts/SkillSystem/Skill_Dash.cs
+++ b/BraveryRPG/Assets/Scripts/SkillSystem/Skill_Dash.cs
@@ -56,7 +56,6 @@ public class Skill_Dash : Skill_Base
     /// </summary>
     private void CreateClone()
     {
-        Debug.Log("Create time echo!");
-        // skill manager clone create clone
+        SkillManager.TimeEcho.CreateTimeEcho();
     }
 }

--- a/BraveryRPG/Assets/Scripts/SkillSystem/Skill_DomainExpansion.cs
+++ b/BraveryRPG/Assets/Scripts/SkillSystem/Skill_DomainExpansion.cs
@@ -76,10 +76,10 @@ public class Skill_DomainExpansion : Skill_Base
     /// <summary>
     /// Pick a random target from the enemies trapped in the Black Hole.
     /// </summary>
-    /// <returns></returns>
     private Transform FindTargetInDomain()
     {
-        // trappedTargets.RemoveAll(target => target == null || target.Health.isDead);
+        // Remove dead enemies to prevent spells from continuing to target and damage them.
+        trappedTargets.RemoveAll(target => target == null || target.health.isDead);
 
         if (trappedTargets.Count == 0) return null;
 
@@ -137,6 +137,11 @@ public class Skill_DomainExpansion : Skill_Base
         return 0;
     }
 
+    /// <summary>
+    /// Checks if this is just the base 'Time Warp' spell tier, which behaves
+    /// like an instant-cast. The two upgrade paths cause the player to rise
+    /// and levitate.
+    /// </summary>
     public bool IsInstantDomain()
     {
         return upgradeType != SkillUpgradeType.Domain_EchoSpam

--- a/BraveryRPG/Assets/Scripts/SkillSystem/Skill_ThrowSword.cs
+++ b/BraveryRPG/Assets/Scripts/SkillSystem/Skill_ThrowSword.cs
@@ -81,7 +81,7 @@ public class Skill_ThrowSword : Skill_Base
         currentSword = newSword.GetComponent<SkillObject_Sword>();
         currentSword.SetupSword(this, GetThrowVelocity());
 
-        // SetSkillOnCooldown();
+        SetSkillOnCooldown();
     }
 
     private GameObject GetSwordPrefab()

--- a/BraveryRPG/Assets/Scripts/StateMachine/PlayerState.cs
+++ b/BraveryRPG/Assets/Scripts/StateMachine/PlayerState.cs
@@ -180,10 +180,20 @@ public abstract class PlayerState : EntityState
             return false;
         }
 
-        if (player.WallDetected || stateMachine.CurrentState == player.DashState)
+        if (player.WallDetected)
         {
             return false;
         }
+
+        if (stateMachine.CurrentState == player.DashState
+            || stateMachine.CurrentState == player.domainExpansionState)
+        {
+            // Prevent the player from dashing out of the Ultimate Spell state,
+            // which is designed to suspend the player in a levitated state
+            // (otherwise, dashing will break the FSM - Finite State Machine).
+            return false;
+        }
+
         return true;
     }
 }

--- a/BraveryRPG/Assets/Scripts/UI/UI_SkillTooltip.cs
+++ b/BraveryRPG/Assets/Scripts/UI/UI_SkillTooltip.cs
@@ -14,6 +14,7 @@ public class UI_SkillTooltip : UI_Tooltip
 
     [SerializeField] private TextMeshProUGUI skillName;
     [SerializeField] private TextMeshProUGUI skillDescription;
+    [SerializeField] private TextMeshProUGUI skillCooldown;
     [SerializeField] private TextMeshProUGUI skillRequirements;
 
     [Space]
@@ -55,6 +56,7 @@ public class UI_SkillTooltip : UI_Tooltip
 
         skillName.text = node.skillData.displayName;
         skillDescription.text = node.skillData.description;
+        skillCooldown.text = "Cooldown " + node.skillData.upgradeData.cooldown + " s.";
 
         string skillLockedText = GetColoredText(hexImportantInfo, lockedSkillText);
         string requirements = node.isLocked


### PR DESCRIPTION
## Improvements:
- Add a background sprite to the Skill Tree UI Background panel.
- Display the skill cooldown in the tooltip window.

## Bugfixes:
- Player is now invulnerable while dashing and casting the ultimate spell.
- You can no longer Dash while channeling the ultimate (which was breaking the FSM).
- Skill cooldown is reset to zero when first unlocking a skill.
- Dead enemies are removed from the target list while channeling the ultimate spell.

## Live Action GIF:
![output](https://github.com/user-attachments/assets/7c7f88e2-310f-42bf-9f35-80b23e2e899b)
